### PR TITLE
Add planner package init

### DIFF
--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for planner


### PR DESCRIPTION
## Summary
- add `planner/__init__.py` as package marker for the planner module

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d8f882ed4832aab5fad4f75851b41